### PR TITLE
This is a sub package to the klevu-smart-search-M2 repository.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,10 +7,11 @@
 		"magento/module-catalog": "@stable",
 		"magento/module-backend": "@stable",
 		"magento/module-eav": "@stable",
-		"magento/framework": "@stable"
+		"magento/framework": "@stable",
+        "zendframework/zend-log": ">=2.5"
     },
     "type": "magento-module",
-    "version": "2.3.17",
+    "version": "2.3.18",
     "license": [
         "OSL-3.0",
         "AFL-3.0"


### PR DESCRIPTION
It is for allowing the CMS content to be indexed with Klevu Search.

Please, see klevu-smart-search-M2/README.md for more information on how to install the overall extension.