### PR TITLE
This is a sub package to the klevu-smart-search-M2 repository.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "klevu/module-logger": "^1.0.0"
     },
     "type": "magento-module",
-    "version": "2.4.2",
+    "version": "2.4.3",
     "license": [
         "OSL-3.0",
         "AFL-3.0"


### PR DESCRIPTION
It is for allowing the CMS content to be indexed with Klevu Search.

Please, see klevu-smart-search-M2/README.md for more information on
how to install the overall extension.