### PR TITLE
This is a sub package to the klevu-smart-search-M2 repository.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "klevu/module-logger": "^1.0.0"
     },
     "type": "magento-module",
-    "version": "2.4.3",
+    "version": "2.5.0",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -23,12 +23,14 @@
         <field id="enabledcmsfront" translate="label" sortOrder="100" type="select" showInDefault="1" showInStore="1">
           <label>Enable Other Content in Frontend</label>
           <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-          <comment><![CDATA[By default, when a search query is fired, Klevu searches in the 
-           product catalog. To enable search in the other content (e.g. CMS and Other non-product content), select Yes.]]></comment>
+          <comment><![CDATA[By default, when a search query is fired, Klevu searches in the
+product catalog. To enable search in the other content (e.g. CMS and Other non-product content), select Yes.<br />
+Note: This option has no effect when using Klevu JSv2 Theme, where you can instead override the templates and
+functionality yourself to achieve the desired result.]]></comment>
         </field>
         <field id="excludecms_pages" translate="label" sortOrder="102" showInDefault="1" showInStore="1">
           <label>Exclude CMS Pages from Search</label>
-		  <frontend_model>Klevu\Content\Block\Adminhtml\Form\Cmspages</frontend_model>
+          <frontend_model>Klevu\Content\Block\Adminhtml\Form\Cmspages</frontend_model>
           <backend_model>Klevu\Search\Model\Config\Backend\Serialized</backend_model>
           <comment><![CDATA[
             This change will take place during the next data sync via Cron, CLI Command or manual sync.


### PR DESCRIPTION
It is for allowing the CMS content to be indexed with Klevu Search.

Please, see klevu-smart-search-M2/README.md for more information on
how to install the overall extension.