### PR TITLE
This is a sub package to the klevu-smart-search-M2 repository.

### DIFF
--- a/Model/Content.php
+++ b/Model/Content.php
@@ -170,7 +170,7 @@ class Content extends \Klevu\Search\Model\Product\Sync implements ContentInterfa
             $this->syncCmsData($store);
         }
     }
-    
+
     /**
      * @param $store
      * @return mixed|void
@@ -481,9 +481,9 @@ class Content extends \Klevu\Search\Model\Product\Sync implements ContentInterfa
             $value["id"] = "pageid_" . $value["page_id"];
             $value["url"] = $base_url . $value["identifier"];
             $desc = preg_replace("/<script\b[^>]*>(.*?)<\/script>/is", "", html_entity_decode($value["content"]));
-            $value["desc"] = preg_replace('#\{{.*?\}}#s', '', strip_tags($this->_contentHelperData->ripTags($desc)));
+            $value["desc"] = preg_replace('#\{{.*?\}}#s', '', strip_tags((string)$this->_contentHelperData->ripTags($desc)));
             $value["metaDesc"] = $value["meta_description"] . $value["meta_keywords"];
-            $value["shortDesc"] = substr(preg_replace('#\{{.*?\}}#s', '', strip_tags($this->_contentHelperData->ripTags($desc))), 0, 200);
+            $value["shortDesc"] = substr(preg_replace('#\{{.*?\}}#s', '', strip_tags((string)$this->_contentHelperData->ripTags($desc))), 0, 200);
             $value["listCategory"] = "KLEVU_CMS";
             $value["category"] = "pages";
             $value["salePrice"] = 0;

--- a/Model/LoadAttribute.php
+++ b/Model/LoadAttribute.php
@@ -56,9 +56,9 @@ class LoadAttribute extends  AbstractModel
             $value["id"] = "pageid_" . $value["page_id"];
             $value["url"] = $base_url . $value["identifier"];
             $desc = preg_replace("/<script\b[^>]*>(.*?)<\/script>/is", "", html_entity_decode($value["content"]));
-            $value["desc"] = preg_replace('#\{{.*?\}}#s', '', strip_tags($this->_contentHelperData->ripTags($desc)));
+            $value["desc"] = preg_replace('#\{{.*?\}}#s', '', strip_tags((string)$this->_contentHelperData->ripTags($desc)));
             $value["metaDesc"] = $value["meta_description"] . $value["meta_keywords"];
-            $value["shortDesc"] = substr(preg_replace('#\{{.*?\}}#s', '', strip_tags($this->_contentHelperData->ripTags($desc))), 0, 200);
+            $value["shortDesc"] = substr(preg_replace('#\{{.*?\}}#s', '', strip_tags((string)$this->_contentHelperData->ripTags($desc))), 0, 200);
             $value["listCategory"] = "KLEVU_CMS";
             $value["category"] = "pages";
             $value["salePrice"] = 0;

--- a/composer.json
+++ b/composer.json
@@ -2,16 +2,16 @@
     "name": "klevu/module-content",
     "description": "Search that learns, generates sales. Fastest, most advanced cloud-based search, autocomplete, instant search",
     "require": {
-		"php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0|~7.2.0|~7.3.0|~7.4.0",
+        "php": "~5.6.0|~7.0.0|~7.1.0|~7.2.0|~7.3.0|~7.4.0|~8.0.0|~8.1.0",
 		"magento/module-store": "@stable",
 		"magento/module-catalog": "@stable",
 		"magento/module-backend": "@stable",
 		"magento/module-eav": "@stable",
 		"magento/framework": "@stable",
-        "klevu/module-logger": "^1.0.0"
+        "klevu/module-logger": "^1.0.0|^2.0.0"
     },
     "type": "magento-module",
-    "version": "2.5.0",
+    "version": "2.6.0",
     "license": [
         "OSL-3.0",
         "AFL-3.0"


### PR DESCRIPTION
It is for allowing the CMS content to be indexed with Klevu Search.

Please, see klevu-smart-search-M2/README.md for more information on
how to install the overall extension.