### PR TITLE
Fix: update console command execute() method signatures for Magento 2.4.9

### DIFF
--- a/Console/Command/SyncContentCommand.php
+++ b/Console/Command/SyncContentCommand.php
@@ -143,7 +143,7 @@ HELP
      * @return int|void
      * @throws LocalizedException
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         // See comments against methods for background. Ref: KS-7853
         $this->initLogger();


### PR DESCRIPTION
This pull request updates the method signatures for the execute methods in several console command classes to explicitly declare their return type as int. This change is required for Magento 2.4.9 because they updated symfony/console to ^7.4.
In this version, the method signature looks like this:
```
protected function execute(InputInterface $input, OutputInterface $output): int
```

The change is backward compatible; it works in old Magento versions.